### PR TITLE
Epsilon value fix

### DIFF
--- a/FlowListView/DLToolkit.Forms.Controls.FlowListView/DLToolkit.Forms.Controls.FlowListView.csproj
+++ b/FlowListView/DLToolkit.Forms.Controls.FlowListView/DLToolkit.Forms.Controls.FlowListView.csproj
@@ -46,24 +46,27 @@
     <Compile Include="FlowSelectors\FlowPropertySelector.cs" />
     <Compile Include="FlowSelectors\FlowFuncPropertySelector.cs" />
     <Compile Include="FlowSorting.cs" />
+    <Compile Include="Epsilon.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\..\Examples\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\Examples\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.0.1.6505\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-  <Import Project="..\..\packages\Xamarin.Forms.2.1.0.6524\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.1.0.6524\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="..\..\packages\Xamarin.Forms.2.1.0.6529\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\packages\Xamarin.Forms.2.1.0.6529\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <ItemGroup>
     <Folder Include="FlowCells\" />
     <Folder Include="FlowSelectors\" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\packages\Xamarin.Forms.2.1.0.6524\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.1.0.6529\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\packages\Xamarin.Forms.2.1.0.6524\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.1.0.6529\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\packages\Xamarin.Forms.2.1.0.6524\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <HintPath>..\..\packages\Xamarin.Forms.2.1.0.6529\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/FlowListView/DLToolkit.Forms.Controls.FlowListView/Epsilon.cs
+++ b/FlowListView/DLToolkit.Forms.Controls.FlowListView/Epsilon.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace DLToolkit.Forms.Controls
+{
+	public struct Epsilon
+	{
+		public const double DoubleValue = 2.22044604925031E-16;
+	}
+}
+

--- a/FlowListView/DLToolkit.Forms.Controls.FlowListView/FlowListView.cs
+++ b/FlowListView/DLToolkit.Forms.Controls.FlowListView/FlowListView.cs
@@ -404,7 +404,7 @@ namespace DLToolkit.Forms.Controls
 
 				if (listWidth > 0)
 				{
-					if ((lastWidth.HasValue && Math.Abs(lastWidth.Value - listWidth) > double.Epsilon)
+					if ((lastWidth.HasValue && Math.Abs(lastWidth.Value - listWidth) > Epsilon.DoubleValue)
 						|| !lastWidth.HasValue)
 					{
 						if (ItemsSource != null)

--- a/FlowListView/DLToolkit.Forms.Controls.FlowListView/FlowListViewInternalCell.cs
+++ b/FlowListView/DLToolkit.Forms.Controls.FlowListView/FlowListViewInternalCell.cs
@@ -211,7 +211,7 @@ namespace DLToolkit.Forms.Controls
 			}
 			else
 			{
-				if (Math.Abs(1d - desiredColumnWidth) < double.Epsilon)
+				if (Math.Abs(1d - desiredColumnWidth) < Epsilon.DoubleValue)
 				{
 					bounds = new Rectangle(1d, 0d, desiredColumnWidth, 1d);	
 				}

--- a/FlowListView/DLToolkit.Forms.Controls.FlowListView/packages.config
+++ b/FlowListView/DLToolkit.Forms.Controls.FlowListView/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Xamarin.Forms" version="2.1.0.6524" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarintvos10+xamarinwatchos10+xamarinios10" />
+  <package id="Xamarin.Forms" version="2.1.0.6529" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
 </packages>


### PR DESCRIPTION
On ARM systems, the double.Epsilon is too small to be detected, so it equates to zero. Must define a value for it. 
If not defined properly and there's only one column, and the application will crash, because it will try to give a view's X position value NaN, as the result of a 0/0 dividing.

Reference: https://bugzilla.xamarin.com/show_bug.cgi?id=8747