### PR TITLE
Ignore Entry Field when Visibility is False

### DIFF
--- a/TagEntryView/DLToolkit.Forms.Controls.TagEntryView/TagEntryView.cs
+++ b/TagEntryView/DLToolkit.Forms.Controls.TagEntryView/TagEntryView.cs
@@ -158,7 +158,7 @@ namespace DLToolkit.Forms.Controls
 				Children.Add(view);
 			}
 
-			Children.Add(TagEntry);
+			if (TagEntry.IsVisible) Children.Add(TagEntry); //via AtlasAF01 (Rob Oller)
 		}
 
 		private void OnSizeChanged()


### PR DESCRIPTION
Change will ignore the entry field, when creating the children collection, if the visibility is set to false.