### PR TITLE
Added optional property for hiding tag entry box and allow keyboard return button

### DIFF
--- a/Samples/DLToolkitControlsSamples/SamplesTagEntryView/TagEntryViewExamplePage.xaml
+++ b/Samples/DLToolkitControlsSamples/SamplesTagEntryView/TagEntryViewExamplePage.xaml
@@ -2,7 +2,7 @@
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="DLToolkitControlsSamples.TagEntryViewExamplePage"
 		xmlns:dltag="clr-namespace:DLToolkit.Forms.Controls;assembly=DLToolkit.Forms.Controls.TagEntryView">
 	<ContentPage.Content>
-		<dltag:TagEntryView TagItems="{Binding Items}" TagTappedCommand="{Binding RemoveTagCommand}" TagValidatorFactory="{StaticResource TagValidatorFactory}">
+		<dltag:TagEntryView TagItems="{Binding Items}" TagTappedCommand="{Binding RemoveTagCommand}" TagValidatorFactory="{StaticResource TagValidatorFactory}" ShowEntryBox="true" AllowKeyboardReturnToAddNewTag="true">
 			<dltag:TagEntryView.TagItemTemplate>
 				<DataTemplate>
 					<Frame BackgroundColor="#2196F3" OutlineColor="Transparent" Padding="10" HasShadow="false">


### PR DESCRIPTION
Added optional property for hiding the TagEntry box so that tag cloud can be readonly and a property for adding a tag when return button on keyboard is pressed. Both are set to default to not change any existing functionality, and I updated the sample to show how to use them.