### PR TITLE
Fix InvalidateCacheEntryAsync

### DIFF
--- a/ImageCropView/ImageCropView.cs
+++ b/ImageCropView/ImageCropView.cs
@@ -499,7 +499,7 @@ namespace DLToolkit.Forms.Controls
                         await ImageService.Instance.InvalidateCacheEntryAsync(_cacheKey, FFImageLoading.Cache.CacheType.Memory, true);
 
                     if (!string.IsNullOrWhiteSpace(_refinedCacheKey))
-                        await ImageService.Instance.InvalidateCacheEntryAsync(_cacheKey, FFImageLoading.Cache.CacheType.Memory, true);
+                        await ImageService.Instance.InvalidateCacheEntryAsync(_refinedCacheKey, FFImageLoading.Cache.CacheType.Memory, true);
 
                     if (source == null)
                     {


### PR DESCRIPTION
If FFImageLoading is greater than 2.4.6.929, ImageCropView no longer works.

Issues Link:
#286 
#268 